### PR TITLE
Optimize subject API to return only required fields

### DIFF
--- a/src/app/api/subjects/[subjectId]/route.ts
+++ b/src/app/api/subjects/[subjectId]/route.ts
@@ -7,6 +7,7 @@ export async function GET(
   { params }: { params: Promise<{ subjectId: string }> }
 ) {
   const { subjectId } = await params;
+
   if (!subjectId) {
     return NextResponse.json(
       { error: "Subject ID is required" },
@@ -17,7 +18,9 @@ export async function GET(
   try {
     await connectToDB();
 
-    const subject = await Subject.findById(subjectId).lean();
+    const subject = await Subject.findById(subjectId)
+      .select("_id name subject_code credits")
+      .lean();
 
     if (!subject) {
       return NextResponse.json({ error: "Subject not found" }, { status: 404 });

--- a/src/app/api/subjects/[subjectId]/route.ts
+++ b/src/app/api/subjects/[subjectId]/route.ts
@@ -7,7 +7,6 @@ export async function GET(
   { params }: { params: Promise<{ subjectId: string }> }
 ) {
   const { subjectId } = await params;
-
   if (!subjectId) {
     return NextResponse.json(
       { error: "Subject ID is required" },
@@ -18,9 +17,7 @@ export async function GET(
   try {
     await connectToDB();
 
-    const subject = await Subject.findById(subjectId)
-      .select("_id name subject_code credits")
-      .lean();
+    const subject = await Subject.findById(subjectId).lean();
 
     if (!subject) {
       return NextResponse.json({ error: "Subject not found" }, { status: 404 });

--- a/src/app/api/subjects/route.ts
+++ b/src/app/api/subjects/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server";
 import { connectToDB } from "@/lib/mongoose";
 import Branch from "@/models/branch-model";
+
 interface BranchDocument {
   name: string;
   subject_ids: Array<{
     _id: string;
     name: string;
-    semester: number;
+    subject_code: string;
+    credits: number;
   }>;
 }
 
@@ -24,8 +26,12 @@ export async function GET(request: Request) {
     }
 
     await connectToDB();
+
     const branchDoc = (await Branch.findOne({ name: branch + sem })
-      .populate<{ subject_ids: BranchDocument["subject_ids"] }>("subject_ids")
+      .populate({
+        path: "subject_ids",
+        select: "_id name subject_code credits",
+      })
       .lean()) as BranchDocument | null;
 
     if (!branchDoc) {


### PR DESCRIPTION
### Description
The subject API was returning the full Subject document even though only a
subset of fields is required by the frontend.

### Changes
- Updated the subject route handler to select only:
  `_id`, `name`, `subject_code`, and `credits`

### Benefits
- Reduced response payload size
- Improved API performance
- Non-breaking change

Closes #1
